### PR TITLE
Add include file for compile

### DIFF
--- a/src/RegisterViewModelBase.cpp
+++ b/src/RegisterViewModelBase.cpp
@@ -6,6 +6,7 @@
 #include "Util.h"
 
 #include <algorithm>
+#include <numeric>
 #include <boost/range/adaptor/reversed.hpp>
 #include <cstdint>
 #include <QBrush>


### PR DESCRIPTION
I've been trying to compile edb on Debian with Debian's "gcc version 5.3.1 20160509 (Debian 5.3.1-19)", and had to include numeric and cmath at various spots in order to complete compile.
