### PR TITLE
Add include file for compile

### DIFF
--- a/plugins/ODbgRegisterView/GPREdit.cpp
+++ b/plugins/ODbgRegisterView/GPREdit.cpp
@@ -1,4 +1,5 @@
 #include "GPREdit.h"
+#include <cmath>
 #include <cstring>
 #include <QApplication>
 #include <QRegExpValidator>


### PR DESCRIPTION
I've been trying to compile edb on Debian with Debian's "gcc version 5.3.1 20160509 (Debian 5.3.1-19)", and had to include numeric and cmath at various spots in order to complete compile.
