### PR TITLE
Add include file for compile

### DIFF
--- a/include/FloatX.h
+++ b/include/FloatX.h
@@ -1,6 +1,7 @@
 #ifndef FLOAT_X_H_20151108
 #define FLOAT_X_H_20151108
 
+#include <cmath>
 #include <type_traits>
 #include <QValidator>
 #include <Types.h>


### PR DESCRIPTION
I've been trying to compile edb on Debian with Debian's "gcc version 5.3.1 20160509 (Debian 5.3.1-19)", and had to include numeric and cmath at various spots in order to complete compile.
